### PR TITLE
modified the code so the JWT token can be validated against multiple …

### DIFF
--- a/src/main/java/uk/gov/cdp/ldap/LdapServiceImpl.java
+++ b/src/main/java/uk/gov/cdp/ldap/LdapServiceImpl.java
@@ -172,7 +172,7 @@ public class LdapServiceImpl implements LdapService
       {
         setUserPassword(context, getUserDN(userName), password);
       }
-      
+
       logger.info("Created user --- {}", userName);
     }
     catch (Exception ex)

--- a/src/test/java/uk/gov/cdp/shadow/user/auth/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/cdp/shadow/user/auth/AuthenticationServiceImplTest.java
@@ -78,11 +78,13 @@ public class AuthenticationServiceImplTest {
 
     try
     {
-      Key pubKey = WsAndHttpJWTAuthenticationHandler.getPublicKey(svc,"");
+      Key pubKey [] = WsAndHttpJWTAuthenticationHandler.getPublicKey(svc,"");
 
-      assert("RS256".equals(pubKey.getAlgorithm()));
-      assert("X.509".equals(pubKey.getFormat()));
-
+      for (int i = 0, ilen = pubKey.length; i < ilen; i++)
+      {
+        assert ("RS256".equals(pubKey[i].getAlgorithm()));
+        assert ("X.509".equals(pubKey[i].getFormat()));
+      }
     }
     catch (Throwable e)
     {


### PR DESCRIPTION
…keys; if the user passes a jwk with the format {keys:[{kid=...},{kid:...}]}, then both keys will be tried in order when validating a JWT token.